### PR TITLE
Fix TypeError: 'CharField' is not subscriptable (Python 3.11+ / 3.12)

### DIFF
--- a/auth_kit/mfa/admin.py
+++ b/auth_kit/mfa/admin.py
@@ -12,7 +12,7 @@ from .models import MFAMethod
 
 
 @admin.register(MFAMethod)
-class MFAMethodAdmin(admin.ModelAdmin[MFAMethod]):
+class MFAMethodAdmin(admin.ModelAdmin):
     """
     Admin interface for MFA method management.
 

--- a/auth_kit/mfa/models.py
+++ b/auth_kit/mfa/models.py
@@ -143,7 +143,7 @@ class MFAMethod(Model):
 
     id: int | None
     user_id: int
-    user = ForeignKey["User", "User"](
+    user = ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=CASCADE,
         verbose_name=_("user"),
@@ -160,17 +160,17 @@ class MFAMethod(Model):
         max_length=255,
         help_text=_("TOTP secret key for generating verification codes"),
     )
-    is_primary = BooleanField[bool, bool](
+    is_primary = BooleanField(
         _("is primary"),
         default=False,
         help_text=_("Whether this is the user's primary MFA method"),
     )
-    is_active = BooleanField[bool, bool](
+    is_active = BooleanField(
         _("is active"),
         default=False,
         help_text=_("Whether this method is active and can be used"),
     )
-    _backup_codes = JSONField[Any, Any](
+    _backup_codes = JSONField(
         _("backup codes"),
         default=dict,
         blank=True,

--- a/auth_kit/mfa/models.py
+++ b/auth_kit/mfa/models.py
@@ -150,12 +150,12 @@ class MFAMethod(Model):
         related_name="mfa_methods",
         help_text=_("User who owns this MFA method"),
     )
-    name = CharField[str, str](
+    name = CharField(
         _("name"),
         max_length=255,
         help_text=_("MFA method name (e.g., 'app', 'email')"),
     )
-    secret = CharField[str, str](
+    secret = CharField(
         _("secret"),
         max_length=255,
         help_text=_("TOTP secret key for generating verification codes"),


### PR DESCRIPTION
While using `auth_kit` with both **Python 3.11.3** and **Python 3.12.3**, I encountered a `TypeError` caused by incorrect subscripted usage of Django model fields.
### 🐛 **Error Traceback**

 ```
TypeError: type 'CharField' is not subscriptable
File ".../auth_kit/mfa/models.py", line 153, in MFAMethod
     name = CharField[str, str](...)
```

This is due to incorrect usage of Django fields like:
```python
name = CharField[str, str](...)
secret = CharField[str, str](...)
```

Django model fields like `CharField`, `BooleanField`, etc., are **not generic** and should **not be subscripted**.

### ✅ **Fix**

I’ve updated the code to:

```python
name = CharField(
    _("name"),
    max_length=255,
    help_text=_("MFA method name (e.g., 'app', 'email')"),
)

secret = CharField(
    _("secret"),
    max_length=255,
    help_text=_("TOTP secret key for generating verification codes"),
)
```
### 💡 Notes

* This fix ensures compatibility with **Python 3.11+** and **Django’s model field requirements**.
* I’ve confirmed the fix resolves the crash during `runserver` and `migrate` in Django 4.2+.
